### PR TITLE
fix(workflows): Correct typos for CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,7 @@ jobs:
         python -m pip install -r requirements.txt
 
 
-    - name: Install dev depenecies
+    - name: Install dev dependencies
       run: |
         python -m pip install black flake8
 


### PR DESCRIPTION
Fix the typo error inside workflows of CI for "dependencies"