### PR TITLE
feat: Add django-summernote for rich text editing

### DIFF
--- a/core/base_admin.py
+++ b/core/base_admin.py
@@ -1,0 +1,41 @@
+from django.contrib import admin
+from django_summernote.widgets import SummernoteWidget
+from django.db import models
+
+
+class SummernoteFieldMixin:
+    """
+    A mixin class that customizes form fields for models with text fields,
+    applying the Summernote widget to enable rich text editing.
+    """
+
+    formfield_overrides = {
+        models.TextField: {"widget": SummernoteWidget()},
+    }
+
+    def formfield_for_dbfield(self, db_field, **kwargs):
+        """
+        Customize the form field for specific database fields.
+        If the field is a TextField, applies the Summernote widget.
+        """
+        if isinstance(db_field, models.TextField):
+            kwargs["widget"] = SummernoteWidget()
+        return super().formfield_for_dbfield(db_field, **kwargs)
+
+
+class SummernoteModelAdmin(SummernoteFieldMixin, admin.ModelAdmin):
+    """
+    A custom ModelAdmin that uses the SummernoteFieldMixin to apply Summernote
+    widgets in the admin, enabling rich text editing for TextFields.
+    """
+
+    pass
+
+
+class SummernoteInlineMixin(SummernoteFieldMixin):
+    """
+    A mixin for inline admin form to apply the Summernote widget for text
+    fields, providing a rich-text editing experience in inline formsets.
+    """
+
+    pass

--- a/core/settings.py
+++ b/core/settings.py
@@ -55,6 +55,7 @@ INSTALLED_APPS = [
     "corsheaders",
     "django_celery_beat",
     "django_celery_results",
+    "django_summernote",
     # django apps
     # todo
     "newsletter",
@@ -191,7 +192,9 @@ STORAGES = {
     },
 }
 
+STATIC_URL = "/static/"
 STATIC_ROOT = os.path.join(BASE_DIR, os.getenv("STATIC_ROOT", "staticfiles"))
+MEDIA_URL = "/media/"
 MEDIA_ROOT = os.path.join(BASE_DIR, os.getenv("MEDIA_ROOT", "media"))
 
 
@@ -276,3 +279,28 @@ JAZZMIN_SETTINGS = {
 }
 USE_X_FORWARDED_HOST = True
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
+SUMMERNOTE_CONFIG = {
+    "summernote": {
+        "width": "100%",
+        "height": "480",
+        "toolbar": [
+            ["style", ["style"]],
+            ["font", ["bold", "italic", "underline", "clear"]],
+            ["fontname", ["fontname"]],
+            ["color", ["color"]],
+            ["para", ["ul", "ol", "paragraph"]],
+            ["table", ["table"]],
+            ["insert", ["link", "picture", "video"]],
+            ["view", ["fullscreen", "codeview"]],
+        ],
+    },
+    # Require users to be authenticated for uploading attachments.
+    "attachment_require_authentication": True,
+    # Set custom storage class for attachments.
+    "attachment_storage_class": (
+        "django.core.files.storage.FileSystemStorage"
+    ),
+    # Set to `False` to return attachment paths in relative URIs.
+    "attachment_absolute_uri": True,
+}

--- a/core/urls.py
+++ b/core/urls.py
@@ -20,6 +20,8 @@ from django.urls import path, include
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
 from rest_framework import permissions
+from django.conf import settings
+from django.conf.urls.static import static
 
 schema_view = get_schema_view(
     openapi.Info(
@@ -42,6 +44,7 @@ urlpatterns = [
         schema_view.with_ui("redoc", cache_timeout=0),
         name="schema-redoc",
     ),
+    path("summernote/", include("django_summernote.urls")),
     path(
         "healthcheck/",
         include("healthcheck.urls"),
@@ -59,3 +62,11 @@ urlpatterns = [
         ),
     ),
 ]
+
+if settings.DEBUG:
+    urlpatterns += static(
+        settings.MEDIA_URL, document_root=settings.MEDIA_ROOT
+    )
+    urlpatterns += static(
+        settings.STATIC_URL, document_root=settings.STATIC_ROOT
+    )

--- a/env.example
+++ b/env.example
@@ -30,3 +30,7 @@ FLOWER_PASSWORD="flower_password"
 
 # Trusted origins for CSRF protection
 DJANGO_CSRF_TRUSTED_ORIGINS=https://nepal.gnome.org
+
+# Static and Media Files
+STATIC_ROOT="staticfiles"
+MEDIA_ROOT="media"

--- a/event/admin.py
+++ b/event/admin.py
@@ -1,5 +1,6 @@
 # Register your models here.
 from . import models
+from core.base_admin import SummernoteModelAdmin, SummernoteInlineMixin
 from django.contrib import admin
 from django import forms
 from nested_admin import (
@@ -14,13 +15,13 @@ class ScheduleAdmin(admin.ModelAdmin):
     search_fields = ["event", "start_time", "end_time"]
 
 
-class EventScheduleInline(NestedStackedInline):
+class EventScheduleInline(SummernoteInlineMixin, NestedStackedInline):
     model = models.Schedule
     extra = 1
     autocomplete_fields = ["speakers"]
 
 
-class EventImagesInline(NestedStackedInline):
+class EventImagesInline(SummernoteInlineMixin, NestedStackedInline):
     model = models.EventImage
     extra = 1
 
@@ -48,7 +49,7 @@ class EventAdminForms(forms.ModelForm):
 
 
 @admin.register(models.Event)
-class EventModelAdmin(NestedModelAdmin):
+class EventModelAdmin(NestedModelAdmin, SummernoteModelAdmin):
     form = EventAdminForms
     list_display = ["title", "is_draft", "start_date", "end_date"]
     search_fields = ["slug", "title"]
@@ -61,7 +62,7 @@ class EventModelAdmin(NestedModelAdmin):
 
 
 @admin.register(models.Speaker)
-class SpeakersAdmin(admin.ModelAdmin):
+class SpeakersAdmin(SummernoteInlineMixin, admin.ModelAdmin):
     list_display = ["name", "profession", "linkedin", "twitter"]
     search_fields = ["name", "profession"]
 
@@ -95,5 +96,6 @@ class HotTopicAdmin(admin.ModelAdmin):
 admin.site.register(
     [
         models.EventImage,
-    ]
+    ],
+    SummernoteModelAdmin,
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ astroid==3.3.5
 attrs==24.2.0
 billiard==4.2.0
 black==24.10.0
+bleach==6.2.0
 Brotli==1.1.0
 celery==5.4.0
 certifi==2024.8.30
@@ -23,6 +24,7 @@ django-nested-admin==4.1.1
 django-redis==5.4.0
 django-stubs==5.1.0
 django-stubs-ext==5.1.0
+django-summernote==0.8.20.0
 django-timezone-field==7.0
 djangorestframework==3.15.2
 drf-yasg==1.21.7
@@ -66,4 +68,5 @@ uritemplate==4.1.1
 urllib3==2.2.3
 vine==5.1.0
 wcwidth==0.2.13
+webencodings==0.5.1
 whitenoise==6.7.0


### PR DESCRIPTION
This PR addresses and resolves issue #48 by implementing the following changes:

- Integrate `django-summernote` package for rich text fields in admin
- Set up `BaseModelAdmin` in `base_admin.py` to apply Summernote to TextFields
- Add `django_summernote` to `INSTALLED_APPS` and configure URLs in `core/urls.py`
- Configure `STATIC_URL` and `MEDIA_URL` in settings, with URL patterns for debug mode
- Apply `BaseModelAdmin` to `Event` model admin for text editing
- Add required storage settings and Summernote configurations in settings