### PR TITLE
chore: update GitHub Actions for workflow improvement

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,19 +3,17 @@ name: GNOME server CI workflow
 on:
   pull_request:
 
-# sets up python code for linting issue
-# and runnable issues
 jobs:
-  lint_and_deploy_test:
+  deploy_test:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
         id: python-setup
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -17,7 +20,4 @@ jobs:
       - name: Add dummy .env file
         run: |
           cp env.example .env
-      - uses: actions/setup-python@main
-        with:
-          cache: 'pip'
-      - uses: pre-commit/action@main
+      - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
- Upgrade actions/checkout and actions/setup-python to latest versions
- Remove pip caching from setup-python for simpler configuration
- Update Python version to 3.12 in Lint workflows
- Rename CI workflow job from "lint_and_deploy" to "deploy_test"
- Resolve annotation warnings related to action versions

Fixes : #64 
